### PR TITLE
Fix bug where publisher thinks a site creation failed

### DIFF
--- a/Controls/ContentAndDbMigrationControl.cs
+++ b/Controls/ContentAndDbMigrationControl.cs
@@ -259,7 +259,7 @@ namespace CompatCheckAndMigrate.Controls
                                 continue;
                             }
 
-                            if (string.IsNullOrEmpty(site.SiteCreationError))
+                            if (!string.IsNullOrEmpty(site.SiteCreationError))
                             {
                                 TraceHelper.Tracer.WriteTrace("ERROR: Skipping publish, site creation error for site: {0}", site.SiteName);
                                 TraceHelper.Tracer.WriteTrace("Site creation error: {0}", site.SiteCreationError);

--- a/Controls/MigrationSite.cs
+++ b/Controls/MigrationSite.cs
@@ -253,6 +253,9 @@ namespace CompatCheckAndMigrate.Controls
         }
         private void BackButton_Click(object sender, EventArgs e)
         {
+            this.publishSettings = null;
+            checkPublishSettingsTimer.Enabled = true;
+            btnPublish.Visible = false;
             if (this.siteBrowser.CanGoBack)
             {
                 this.siteBrowser.GoBack();


### PR DESCRIPTION
If sitecreationerror is null or empty, that means that no error occured. As such, we shouldn't be executing that block.

Fix issue where if site creation fails and user goes back to try again, the app would continue to think the site creation failed even if it works the second time through.